### PR TITLE
Refactor Dockerfile for a safer and simplest Production-ready image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
   speech-processor:
     resource_class: small
     docker:
-      - image: cimg/python:3.10.0
+      - image: python:3.10-slim
       - *mongodb-container
     environment:
       GOOGLE_LOCAL: '1'
@@ -24,7 +24,7 @@ jobs:
           command: pip3 install --no-cache-dir -r requirements-dev.txt
       - run:
           name: "Install ffmpeg"
-          command: sudo apt-get -y update && sudo apt-get install -y ffmpeg
+          command: apt-get -y update && apt-get install -y ffmpeg
       - run:
           name: "Run Tests"
           command: python3 -u -m pytest tests --tb=native -rP

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
   speech-processor:
     resource_class: small
     docker:
-      - image: martouta/python_audio_google_cloud:v2
+      - image: cimg/python:3.10.0
       - *mongodb-container
     environment:
       GOOGLE_LOCAL: '1'
@@ -20,8 +20,14 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Install Python Development requirements"
+          command: pip3 install --no-cache-dir -r requirements-dev.txt
+      - run:
+          name: "Install ffmpeg"
+          command: sudo apt-get -y update && sudo apt-get install -y ffmpeg
+      - run:
           name: "Run Tests"
-          command: cd /root/project && python3 -u -m pytest tests --tb=native -rP
+          command: python3 -u -m pytest tests --tb=native -rP
 
 ####### CIRCLECI WORKFLOWS #######
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM martouta/python_audio_google_cloud:v2
+FROM python:3.10-slim
 
 SHELL ["/bin/bash", "-c"]
 
-RUN apt-get -y update && apt-get -y upgrade && apt-get -y autoremove \
-    && apt-get install -y -q --no-install-recommends -o Dpkg::Options::="--force-confold" netcat
-
 WORKDIR /usr/src/app
-COPY . /usr/src/app
+
+COPY requirements.txt __main__.py .
+COPY app app
+COPY audio_chunks audio_chunks
+COPY audios audios
+COPY config config
+COPY subtitles subtitles
+COPY videos videos
+
+RUN pip3 install --no-cache-dir -r requirements.txt \
+    && apt-get -y update && apt-get -y upgrade && apt-get -y autoremove \
+    && apt-get install -y ffmpeg \
+    && apt-get install -y -q --no-install-recommends -o Dpkg::Options::="--force-confold" netcat \
+    && mkdir /usr/src/app/log
 
 CMD ["python3", "-u" , "."]

--- a/Dockerfile.python_audio_google_cloud
+++ b/Dockerfile.python_audio_google_cloud
@@ -1,5 +1,0 @@
-FROM python:3.10-slim
-
-COPY requirements-dev.txt ./
-RUN pip3 install --no-cache-dir -r requirements-dev.txt \
-    && apt-get -y update && apt-get -y upgrade && apt-get install -y ffmpeg


### PR DESCRIPTION
- Use one single Dockerfile
- Use requirements.txt
- Copy only the files/folders I need in production. Plus, I do not take the risk to leak my google cloud speech credentials.

Merging this implies building the image and pushing.
`docker build -t martouta/speech_processor:v1.0.0 -f Dockerfile . && docker push martouta/speech_processor:v1.0.0`