### PR TITLE
Recognise chunks in Google Cloud only through default credentials

### DIFF
--- a/app/resource_audio.py
+++ b/app/resource_audio.py
@@ -57,18 +57,6 @@ class ResourceAudio:
         return Subtitle(self.recognition_id, all_recognitions, language)
 
     def __recognize_chunk(self, filepath, language):
-        if (os.getenv('GOOGLE_LOCAL', '1') == '1'):
-            return ResourceAudio.__recognize_local(filepath, language)
-        else:
-            response = ResourceAudio.__recognize_cloud(filepath, language)
-            return response.results[0].alternatives[0].transcript
-
-    def __path_chunks(self):
-        sp_path = Path(__file__).resolve().parent.parent
-        return f"{sp_path}/audio_chunks/{os.environ['SPEECH_ENV']}/{self.recognition_id}"
-
-    @staticmethod
-    def __recognize_local(filepath, language):
         try:
             with sr.AudioFile(filepath) as audiofile:
                 recognizer = sr.Recognizer()
@@ -81,17 +69,6 @@ class ResourceAudio:
                 'Could not request results. check your internet connection')
             return ''
 
-    @staticmethod
-    def __recognize_cloud(filepath, language):
-        with io.open(filepath, 'rb') as audiofile:
-            info = mediainfo(filepath)
-            content = audiofile.read()
-            client = speech.SpeechClient()
-            audio = speech.RecognitionAudio(content=content)
-            config = speech.RecognitionConfig(
-                encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
-                language_code=language,
-                sample_rate_hertz=int(info['sample_rate']),
-                audio_channel_count=int(info['channels'])
-            )
-            return client.recognize(config=config, audio=audio)
+    def __path_chunks(self):
+        sp_path = Path(__file__).resolve().parent.parent
+        return f"{sp_path}/audio_chunks/{os.environ['SPEECH_ENV']}/{self.recognition_id}"

--- a/tests/test_process_resource.py
+++ b/tests/test_process_resource.py
@@ -30,7 +30,6 @@ class TestProcessResource:
             os.remove(fname)
 
     @httpretty.activate(verbose=True, allow_net_connect=False)
-    @mock.patch.dict(os.environ, {'GOOGLE_LOCAL': '1'})
     def test_process_resource_correctly(self):
         api_url = "http://www.google.com/speech-api/v2/recognize?client=chromium&lang=ar&key=AIzaSyBOti4mM-6x9WDnZIjIeyEU21OpBXqWBgw"
         httpretty.register_uri(
@@ -86,7 +85,6 @@ class TestProcessResource:
         assert doc['lines'] == expected_recognition
 
     @httpretty.activate(verbose=True, allow_net_connect=False)
-    @mock.patch.dict(os.environ, {'GOOGLE_LOCAL': '1'})
     @mock.patch.dict(os.environ, {'SUBS_LOCATION': 'file'})
     def test_process_resource_save_in_file(self):
         api_url = "http://www.google.com/speech-api/v2/recognize?client=chromium&lang=ar&key=AIzaSyBOti4mM-6x9WDnZIjIeyEU21OpBXqWBgw"

--- a/tests/test_resource_audio.py
+++ b/tests/test_resource_audio.py
@@ -46,7 +46,6 @@ class TestResourceAudio:
             './audio_chunks/test/recognition_id/chunk*wav')) == chunks_info['number']
 
     @httpretty.activate(verbose=True, allow_net_connect=False)
-    @mock.patch.dict(os.environ, {'GOOGLE_LOCAL': '1'})
     def test_recognize_chunks_google_local(self):
         filepath = f"{os.getcwd()}/tests/fixtures/example.mp3"
         resource_audio = ResourceAudio.save_as_wav('recognition_id', filepath)


### PR DESCRIPTION
This implies getting rid of the ENV var 'GOOGLE_LOCAL'
Closes #1