### PR TITLE
Make ResourceAudio.save_as_wav more memory-friendly 🐘

### DIFF
--- a/app/models/resource_audio.py
+++ b/app/models/resource_audio.py
@@ -2,6 +2,7 @@ import fnmatch
 import os
 import re
 from pathlib import Path
+import subprocess
 from pydub import AudioSegment
 from pydub.silence import split_on_silence
 from .duration import Duration
@@ -29,10 +30,14 @@ class ResourceAudio:
     def save_as_wav(recognition_id, original_file_path):
         path_regexp = "^.*\\/([^/]*)\\.[^.]*$"
         name = re.match(path_regexp, original_file_path).group(1)
-        sound = AudioSegment.from_file(original_file_path)
         sp_path = Path(__file__).resolve().parent.parent.parent
         new_path = f"{sp_path}/resources/multimedia/{os.environ['SPEECH_ENV']}/{name}.wav"
-        sound.export(new_path, format='wav')
+
+        if original_file_path != new_path:
+            command = ['ffmpeg', '-y', '-i', original_file_path,
+                       '-acodec', 'pcm_s16le', '-ar', '16000', new_path]
+            subprocess.run(command, check=True, stderr=subprocess.DEVNULL)
+
         return ResourceAudio(recognition_id, AudioSegment.from_wav(new_path))
 
     def split_into_chunks(self):

--- a/tests/fixtures/invalid.wav
+++ b/tests/fixtures/invalid.wav
@@ -1,0 +1,1 @@
+Hello, World!

--- a/tests/models/test_resource_audio.py
+++ b/tests/models/test_resource_audio.py
@@ -1,4 +1,5 @@
 import glob
+import subprocess
 from app.input_items.recognizer_data import RecognizerData
 from app.models.resource_audio import ResourceAudio
 import httpretty
@@ -37,15 +38,30 @@ class TestResourceAudio:
     def test_save_as_wav_for_wav(self):
         self.assert_save_wav_for(format='wav')
 
-    def test_save_as_wav_non_existent(self):
+    def test_save_as_wav_non_existent_origin(self):
         filepath = f"{os.getcwd()}/tests/fixtures/fake.fake"
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(subprocess.CalledProcessError):
             ResourceAudio.save_as_wav('recognition_id', filepath)
 
     def test_save_as_wav_invalid_format(self):
         filepath = f"{os.getcwd()}/tests/fixtures/example.txt"
-        with pytest.raises(pydub.exceptions.CouldntDecodeError):
+        with pytest.raises(subprocess.CalledProcessError):
             ResourceAudio.save_as_wav('recognition_id', filepath)
+
+    def test_save_as_wav_invalid_audio(self):
+        filepath = f"{os.getcwd()}/tests/fixtures/invalid.wav"
+        with pytest.raises(subprocess.CalledProcessError):
+            ResourceAudio.save_as_wav('recognition_id', filepath)
+
+    def test_save_as_wav_when_origin_is_same_as_destination(self):
+        example_downloaded_path = f"{os.getcwd()}/resources/multimedia/test/example.wav"
+        fixture_filepath = f"{os.getcwd()}/tests/fixtures/example.wav"
+        shutil.copyfile(fixture_filepath, example_downloaded_path)
+        assert os.path.exists(example_downloaded_path)
+
+        resource_audio = ResourceAudio.save_as_wav(
+            'recognition_id', example_downloaded_path)
+        assert type(resource_audio) == ResourceAudio
 
     def test_split_into_chunks(self):
         sound = AudioSegment.from_file(
@@ -88,8 +104,8 @@ class TestResourceAudio:
         resource_audio = self.setup_recognize_all_chunks(filepath)
 
         expected_recognition = [
-            '00:00:00,000;00:00:01,328;بخير وانت',
-            '00:00:01,328;00:00:01,928;شكرا'
+            '00:00:00,000;00:00:01,329;بخير وانت',
+            '00:00:01,329;00:00:01,927;شكرا'
         ]
 
         responses = [
@@ -113,7 +129,7 @@ class TestResourceAudio:
         resource_audio = self.setup_recognize_all_chunks(filepath)
 
         expected_recognition = [
-            '00:00:01,328;00:00:01,928;شكرا'
+            '00:00:01,329;00:00:01,927;شكرا'
         ]
 
         responses = [

--- a/tests/services/test_temporary_files_cleaner.py
+++ b/tests/services/test_temporary_files_cleaner.py
@@ -5,7 +5,7 @@ from app.services.temporary_files_cleaner import TemporaryFilesCleaner
 
 
 class TestTemporaryFilesCleaner:
-    VIDEO_FIXTURE_FILE_PATH = f"{os.getcwd()}/tests/fixtures/example.mp4"
+    FIXTURE_FILE_PARTIAL_PATH = f"{os.getcwd()}/tests/fixtures/example"
 
     def test_cleanup_temporary_files_when_they_exist_for_video_mp4(self):
         self.assert_cleanup_temporary_files_when_they_exist('mp4')
@@ -32,8 +32,8 @@ class TestTemporaryFilesCleaner:
         multimedia_name = f"{recognition_id}-example"
 
         downloaded_multimedia_path = f"{os.getcwd()}/resources/multimedia/test/{multimedia_name}.{format}"
-        shutil.copyfile(
-            TestTemporaryFilesCleaner.VIDEO_FIXTURE_FILE_PATH, downloaded_multimedia_path)
+        fixture_path = f"{self.FIXTURE_FILE_PARTIAL_PATH}.{format}"
+        shutil.copyfile(fixture_path, downloaded_multimedia_path)
         assert os.path.exists(downloaded_multimedia_path)
 
         ResourceAudio.save_as_wav(


### PR DESCRIPTION
Part of #59
Use FFmpeg to convert the file without loading it into memory.