### PR TITLE
[Feature] Log to file or stdout/stderr or both

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,12 +1,12 @@
 import app
 import concurrent.futures
-import logging
 import os
-import sys
 
 
 def main() -> None:
-    config_logs()
+    log_output = os.environ.get('LOG_OUTPUT', 'file')
+    log_configurator = app.LogConfigurator(log_output)
+    log_configurator.configure_logging()
     process_threaded_inputs()
 
 
@@ -15,59 +15,6 @@ def process_threaded_inputs():
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         for msg in app.fetch_input_messages():
             executor.submit(app.process_resource, msg)
-
-
-def create_file_handler(logFilePath):
-    file_handler = logging.FileHandler(logFilePath)
-    return file_handler
-
-
-def create_standard_handlers():
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stderr_handler = logging.StreamHandler(sys.stderr)
-    return stdout_handler, stderr_handler
-
-
-def set_handler_level(handler, level, filter_func=None):
-    handler.setLevel(level)
-    if filter_func:
-        handler.addFilter(filter_func)
-
-
-def configure_handler(handler, log_output, logFormatter, root, stdout_handler=None, stderr_handler=None):
-    handler.setFormatter(logFormatter)
-    root.addHandler(handler)
-
-    if log_output in ['standard', 'both']:
-        if handler is stdout_handler:
-            set_handler_level(handler, logging.INFO,
-                              lambda record: record.levelno <= logging.INFO)
-        elif handler is stderr_handler:
-            set_handler_level(handler, logging.ERROR)
-    else:
-        set_handler_level(handler, logging.INFO)
-
-
-def config_logs():
-    speech_env = os.environ['SPEECH_ENV']
-    log_output = os.environ.get('LOG_OUTPUT', 'file')
-    logFilePath = f"log/{speech_env}.log"
-    logFormatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    root = logging.getLogger()
-
-    root.setLevel(logging.INFO)
-
-    if log_output in ['file', 'both']:
-        file_handler = create_file_handler(logFilePath)
-        configure_handler(file_handler, log_output, logFormatter, root)
-
-    if log_output in ['standard', 'both']:
-        stdout_handler, stderr_handler = create_standard_handlers()
-        configure_handler(stdout_handler, log_output, logFormatter, root,
-                          stdout_handler=stdout_handler, stderr_handler=stderr_handler)
-        configure_handler(stderr_handler, log_output, logFormatter, root,
-                          stdout_handler=stdout_handler, stderr_handler=stderr_handler)
 
 
 if __name__ == '__main__':

--- a/__main__.py
+++ b/__main__.py
@@ -17,23 +17,57 @@ def process_threaded_inputs():
             executor.submit(app.process_resource, msg)
 
 
+def create_file_handler(logFilePath):
+    file_handler = logging.FileHandler(logFilePath)
+    return file_handler
+
+
+def create_standard_handlers():
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    return stdout_handler, stderr_handler
+
+
+def set_handler_level(handler, level, filter_func=None):
+    handler.setLevel(level)
+    if filter_func:
+        handler.addFilter(filter_func)
+
+
+def configure_handler(handler, log_output, logFormatter, root, stdout_handler=None, stderr_handler=None):
+    handler.setFormatter(logFormatter)
+    root.addHandler(handler)
+
+    if log_output in ['standard', 'both']:
+        if handler is stdout_handler:
+            set_handler_level(handler, logging.INFO,
+                              lambda record: record.levelno <= logging.INFO)
+        elif handler is stderr_handler:
+            set_handler_level(handler, logging.ERROR)
+    else:
+        set_handler_level(handler, logging.INFO)
+
+
 def config_logs():
     speech_env = os.environ['SPEECH_ENV']
+    log_output = os.environ.get('LOG_OUTPUT', 'file')
     logFilePath = f"log/{speech_env}.log"
     logFormatter = logging.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     root = logging.getLogger()
 
-    handler_collection = [logging.FileHandler(logFilePath)]
-    if speech_env != 'test':
-        handler_collection.append(logging.StreamHandler(sys.stdout))
+    root.setLevel(logging.INFO)
 
-    for logging_level in [logging.ERROR, logging.INFO]:
-        root.setLevel(logging_level)
-        for handler in handler_collection:
-            handler.setLevel(logging_level)
-            handler.setFormatter(logFormatter)
-            root.addHandler(handler)
+    if log_output in ['file', 'both']:
+        file_handler = create_file_handler(logFilePath)
+        configure_handler(file_handler, log_output, logFormatter, root)
+
+    if log_output in ['standard', 'both']:
+        stdout_handler, stderr_handler = create_standard_handlers()
+        configure_handler(stdout_handler, log_output, logFormatter, root,
+                          stdout_handler=stdout_handler, stderr_handler=stderr_handler)
+        configure_handler(stderr_handler, log_output, logFormatter, root,
+                          stdout_handler=stdout_handler, stderr_handler=stderr_handler)
 
 
 if __name__ == '__main__':

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,2 +1,3 @@
 from .fetch_input_messages import fetch_input_messages
 from .process_resource import process_resource
+from .log_configurator import LogConfigurator

--- a/app/log_configurator.py
+++ b/app/log_configurator.py
@@ -1,0 +1,36 @@
+import logging
+import os
+import sys
+
+
+class LogConfigurator:
+    def __init__(self, log_output='file'):
+        self.log_output = log_output
+
+    def configure_logging(self):
+        logFormatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        root = logging.getLogger()
+        root.setLevel(logging.INFO)
+
+        if self.log_output in ['file', 'both']:
+            file_handler = self._create_file_handler()
+            self._configure_handler(file_handler, logFormatter, root)
+
+        if self.log_output in ['standard', 'both']:
+            stdout_handler, stderr_handler = self._create_standard_handlers()
+            self._configure_handler(stdout_handler, logFormatter, root)
+            self._configure_handler(stderr_handler, logFormatter, root)
+
+    def _create_file_handler(self):
+        logFilePath = f"log/{os.environ['SPEECH_ENV']}.log"
+        return logging.FileHandler(logFilePath)
+
+    def _create_standard_handlers(self):
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        return stdout_handler, stderr_handler
+
+    def _configure_handler(self, handler, logFormatter, root):
+        handler.setFormatter(logFormatter)
+        root.addHandler(handler)

--- a/tests/test_log_configurator.py
+++ b/tests/test_log_configurator.py
@@ -1,0 +1,60 @@
+import logging
+import sys
+import pytest
+from app.log_configurator import LogConfigurator
+
+
+class TestLogConfigurator:
+    @pytest.fixture(autouse=True)
+    def setUp(self, caplog):
+        caplog.set_level(logging.NOTSET)
+        self.root_logger = logging.getLogger()
+
+    def test_configure_logging_file(self):
+        log_output = 'file'
+        log_configurator = LogConfigurator(log_output)
+
+        initial_handler_count = len(self.root_logger.handlers)
+
+        log_configurator.configure_logging()
+
+        handlers = self.root_logger.handlers
+        added_handler_count = len(handlers) - initial_handler_count
+
+        assert added_handler_count == 1
+        assert isinstance(handlers[-1], logging.FileHandler)
+
+    def test_configure_logging_standard(self):
+        log_output = 'standard'
+        log_configurator = LogConfigurator(log_output)
+
+        initial_handler_count = len(self.root_logger.handlers)
+
+        log_configurator.configure_logging()
+
+        handlers = self.root_logger.handlers
+        added_handler_count = len(handlers) - initial_handler_count
+
+        assert added_handler_count == 2
+        assert isinstance(handlers[-2], logging.StreamHandler)
+        assert isinstance(handlers[-1], logging.StreamHandler)
+        assert handlers[-2].stream == sys.stdout
+        assert handlers[-1].stream == sys.stderr
+
+    def test_configure_logging_both(self):
+        log_output = 'both'
+        log_configurator = LogConfigurator(log_output)
+
+        initial_handler_count = len(self.root_logger.handlers)
+
+        log_configurator.configure_logging()
+
+        handlers = self.root_logger.handlers
+        added_handler_count = len(handlers) - initial_handler_count
+
+        assert added_handler_count == 3
+        assert isinstance(handlers[-3], logging.FileHandler)
+        assert isinstance(handlers[-2], logging.StreamHandler)
+        assert isinstance(handlers[-1], logging.StreamHandler)
+        assert handlers[-2].stream == sys.stdout
+        assert handlers[-1].stream == sys.stderr


### PR DESCRIPTION
- Add separate functions for creating file and standard (stdout, stderr) handlers
- Introduce set_handler_level and configure_handler functions for better modularity
- Update config_logs function to use the new helper functions and handle LOG_OUTPUT environment variable
- LOG_OUTPUT supports 'file', 'standard', and 'both' options for flexible logging